### PR TITLE
Padronização dos Controllers

### DIFF
--- a/infra/controller.js
+++ b/infra/controller.js
@@ -1,0 +1,25 @@
+import { InternalServerError, MethodNotAllowedError } from "infra/errors.js";
+
+function onNoMatchHandler(request, response) {
+  const publicErrorObject = new MethodNotAllowedError();
+  console.error(publicErrorObject);
+  response.status(publicErrorObject.statusCode).json(publicErrorObject);
+}
+
+function onErrorHandler(error, request, response) {
+    const publicErrorObject = new InternalServerError({
+      statusCode: error.statusCode,
+      cause: error,
+    });
+    console.error(publicErrorObject);
+    response.status(publicErrorObject.statusCode).json(publicErrorObject);
+}
+
+const controller = {
+  errorHandler: {
+    onNoMatch: onNoMatchHandler,
+    onError: onErrorHandler
+  }
+};
+
+export default controller;

--- a/infra/controller.js
+++ b/infra/controller.js
@@ -7,19 +7,19 @@ function onNoMatchHandler(request, response) {
 }
 
 function onErrorHandler(error, request, response) {
-    const publicErrorObject = new InternalServerError({
-      statusCode: error.statusCode,
-      cause: error,
-    });
-    console.error(publicErrorObject);
-    response.status(publicErrorObject.statusCode).json(publicErrorObject);
+  const publicErrorObject = new InternalServerError({
+    statusCode: error.statusCode,
+    cause: error,
+  });
+  console.error(publicErrorObject);
+  response.status(publicErrorObject.statusCode).json(publicErrorObject);
 }
 
 const controller = {
   errorHandler: {
     onNoMatch: onNoMatchHandler,
-    onError: onErrorHandler
-  }
+    onError: onErrorHandler,
+  },
 };
 
 export default controller;

--- a/infra/database.js
+++ b/infra/database.js
@@ -24,7 +24,7 @@ async function query(queryObject) {
   } catch (error) {
     const serviceErrorObject = new ServiceError({
       cause: error,
-      message: "Erro na conexão com o Banco ou na Query."
+      message: "Erro na conexão com o Banco ou na Query.",
     });
     throw serviceErrorObject;
   } finally {

--- a/infra/database.js
+++ b/infra/database.js
@@ -1,4 +1,5 @@
 import { Client } from "pg";
+import { ServiceError } from "./errors.js";
 
 async function getNewClient() {
   const client = new Client({
@@ -21,9 +22,11 @@ async function query(queryObject) {
     const result = await client.query(queryObject);
     return result;
   } catch (error) {
-    console.log("\n Erro do database \n");
-    console.error(error);
-    throw error;
+    const serviceErrorObject = new ServiceError({
+      cause: error,
+      message: "Erro na conexão com o Banco ou na Query."
+    });
+    throw serviceErrorObject;
   } finally {
     await client?.end();
   }

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -42,7 +42,8 @@ export class MethodNotAllowedError extends Error {
   constructor() {
     super("Método não permitido para este endpoint.");
     this.name = "MethodNotAllowedError";
-    this.action = "Verifique se o método HTTP enviado é válido para este endpoint.";
+    this.action =
+      "Verifique se o método HTTP enviado é válido para este endpoint.";
     this.statusCode = 405;
   }
 

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -1,11 +1,11 @@
 export class InternalServerError extends Error {
-  constructor({ cause }) {
+  constructor({ cause, statusCode }) {
     super("Um erro interno não esperado aconteceu.", {
       cause,
     });
     this.name = "InternalServerError";
     this.action = "Contate o suporte";
-    this.statusCode = 500;
+    this.statusCode = statusCode || 500;
   }
 
   toJSON() {
@@ -13,7 +13,45 @@ export class InternalServerError extends Error {
       name: this.name,
       message: this.message,
       action: this.action,
-      status: this.statusCode,
+      status_code: this.statusCode,
+    };
+  }
+}
+
+export class ServiceError extends Error {
+  constructor({ cause, message }) {
+    super(message || "Serviço indisponível no momento.", {
+      cause,
+    });
+    this.name = "ServiceError";
+    this.action = "Verifique se o serviço está disponível.";
+    this.statusCode = 503;
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}
+
+export class MethodNotAllowedError extends Error {
+  constructor() {
+    super("Método não permitido para este endpoint.");
+    this.name = "MethodNotAllowedError";
+    this.action = "Verifique se o método HTTP enviado é válido para este endpoint.";
+    this.statusCode = 405;
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
     };
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "dotenv": "16.4.5",
         "dotenv-expand": "11.0.6",
         "next": "14.2.6",
+        "next-connect": "1.0.0",
         "node-pg-migrate": "7.6.1",
         "pg": "8.12.0",
         "react": "18.3.1",
@@ -2088,6 +2089,12 @@
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -8550,6 +8557,19 @@
         }
       }
     },
+    "node_modules/next-connect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-connect/-/next-connect-1.0.0.tgz",
+      "integrity": "sha512-FeLURm9MdvzY1SDUGE74tk66mukSqL6MAzxajW7Gqh6DZKBZLrXmXnGWtHJZXkfvoi+V/DUe9Hhtfkl4+nTlYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsconfig/node16": "^1.0.3",
+        "regexparam": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -9589,6 +9609,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexparam": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/regexparam/-/regexparam-2.0.2.tgz",
+      "integrity": "sha512-A1PeDEYMrkLrfyOwv2jwihXbo9qxdGD3atBYQA9JJgreAx8/7rC6IUkWOw2NQlOxLp2wL0ifQbh1HuidDfYA6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "dotenv": "16.4.5",
     "dotenv-expand": "11.0.6",
     "next": "14.2.6",
+    "next-connect": "1.0.0",
     "node-pg-migrate": "7.6.1",
     "pg": "8.12.0",
     "react": "18.3.1",

--- a/pages/api/v1/migrations/index.js
+++ b/pages/api/v1/migrations/index.js
@@ -1,20 +1,21 @@
+import { createRouter } from "next-connect"
 import migrationRunner from "node-pg-migrate";
 import { resolve } from "node:path";
 import database from "infra/database";
+import controller from "infra/controller"
 
-export default async function migrations(request, response) {
-  const allowedMethods = ["GET", "POST"];
-  if (!allowedMethods.includes(request.method)) {
-    return response.status(405).json({
-      error: `Method "${request.method}" not allowed`,
-    });
-  }
+const router = createRouter();
 
+router.get(getHandler).post(postHandler);
+
+export default router.handler(controller.errorHandler);
+ 
+async function getHandler(request, response) {
   let dbClient;
-  try {
+  try{
     dbClient = await database.getNewClient();
-
-    const defaultMigrationsOptions = {
+  
+    const migrationsOptions = {
       dbClient: dbClient,
       dryRun: true,
       dir: resolve("infra", "migrations"),
@@ -22,26 +23,34 @@ export default async function migrations(request, response) {
       verbose: true,
       migrationsTable: "pgmigrations",
     };
-
-    if (request.method === "GET") {
-      const PendingMigrations = await migrationRunner(defaultMigrationsOptions);
-      return response.status(200).json(PendingMigrations);
-    }
-
-    if (request.method === "POST") {
-      const migratedMigrations = await migrationRunner({
-        ...defaultMigrationsOptions,
-        dryRun: false,
-      });
-      if (migratedMigrations.length > 0) {
-        return response.status(201).json(migratedMigrations);
-      }
-      return response.status(200).json(migratedMigrations);
-    }
-  } catch (error) {
-    console.error(error);
-    throw error;
+  
+    const PendingMigrations = await migrationRunner(migrationsOptions);
+    return response.status(200).json(PendingMigrations);
   } finally {
-    await dbClient.end();
+    await dbClient?.end();
+  }
+}
+
+async function postHandler(request, response) {
+  let dbClient;
+  try{
+    dbClient = await database.getNewClient();
+
+    const migrationsOptions = {
+      dbClient: dbClient,
+      dryRun: false,
+      dir: resolve("infra", "migrations"),
+      direction: "up",
+      verbose: true,
+      migrationsTable: "pgmigrations",
+    };
+
+    const migratedMigrations = await migrationRunner(migrationsOptions);
+    if (migratedMigrations.length > 0) {
+      return response.status(201).json(migratedMigrations);
+    }
+    return response.status(200).json(migratedMigrations);
+  } finally {
+    await dbClient?.end();
   }
 }

--- a/pages/api/v1/migrations/index.js
+++ b/pages/api/v1/migrations/index.js
@@ -1,20 +1,20 @@
-import { createRouter } from "next-connect"
+import { createRouter } from "next-connect";
 import migrationRunner from "node-pg-migrate";
 import { resolve } from "node:path";
 import database from "infra/database";
-import controller from "infra/controller"
+import controller from "infra/controller";
 
 const router = createRouter();
 
 router.get(getHandler).post(postHandler);
 
 export default router.handler(controller.errorHandler);
- 
+
 async function getHandler(request, response) {
   let dbClient;
-  try{
+  try {
     dbClient = await database.getNewClient();
-  
+
     const migrationsOptions = {
       dbClient: dbClient,
       dryRun: true,
@@ -23,7 +23,7 @@ async function getHandler(request, response) {
       verbose: true,
       migrationsTable: "pgmigrations",
     };
-  
+
     const PendingMigrations = await migrationRunner(migrationsOptions);
     return response.status(200).json(PendingMigrations);
   } finally {
@@ -33,7 +33,7 @@ async function getHandler(request, response) {
 
 async function postHandler(request, response) {
   let dbClient;
-  try{
+  try {
     dbClient = await database.getNewClient();
 
     const migrationsOptions = {

--- a/pages/api/v1/status/index.js
+++ b/pages/api/v1/status/index.js
@@ -1,48 +1,42 @@
+import { createRouter } from "next-connect"
 import database from "infra/database.js";
-import { InternalServerError } from "infra/errors.js";
+import controller from "infra/controller"
 
-async function status(request, response) {
-  try {
-    const updatedAT = new Date().toISOString();
+const router = createRouter();
 
-    const databaseVersionResult = await database.query("SHOW server_version;");
-    const databaseVersionValue = databaseVersionResult.rows[0].server_version;
+router.get(getHandler);
 
-    const databaseMaxConnectionsResult = await database.query(
-      "SHOW max_connections;",
-    );
-    const databaseMaxConnectionsValue = parseInt(
-      databaseMaxConnectionsResult.rows[0].max_connections,
-    );
+export default router.handler(controller.errorHandler);
 
-    const databaseName = process.env.POSTGRES_DB;
-    const databaseOpenedConnectionsResult = await database.query({
-      text: "SELECT count(*)::int FROM pg_stat_activity WHERE datname = $1;",
-      values: [databaseName],
-    });
-    const databaseOpenedConnectionsValue =
-      databaseOpenedConnectionsResult.rows[0].count;
+async function getHandler(request, response) {
+  const updatedAT = new Date().toISOString();
 
-    response.status(200).json({
-      updated_at: updatedAT,
-      dependecies: {
-        database: {
-          version: databaseVersionValue,
-          max_connections: databaseMaxConnectionsValue,
-          opened_connections: databaseOpenedConnectionsValue,
-        },
+  const databaseVersionResult = await database.query("SHOW server_version;");
+  const databaseVersionValue = databaseVersionResult.rows[0].server_version;
+
+  const databaseMaxConnectionsResult = await database.query(
+    "SHOW max_connections;",
+  );
+  const databaseMaxConnectionsValue = parseInt(
+    databaseMaxConnectionsResult.rows[0].max_connections,
+  );
+
+  const databaseName = process.env.POSTGRES_DB;
+  const databaseOpenedConnectionsResult = await database.query({
+    text: "SELECT count(*)::int FROM pg_stat_activity WHERE datname = $1;",
+    values: [databaseName],
+  });
+  const databaseOpenedConnectionsValue =
+    databaseOpenedConnectionsResult.rows[0].count;
+
+  response.status(200).json({
+    updated_at: updatedAT,
+    dependecies: {
+      database: {
+        version: databaseVersionValue,
+        max_connections: databaseMaxConnectionsValue,
+        opened_connections: databaseOpenedConnectionsValue,
       },
-    });
-  } catch (error) {
-    const publicErrorObject = new InternalServerError({
-      cause: error,
-    });
-
-    console.log("\n Erro do controller \n");
-    console.error(publicErrorObject);
-
-    response.status(500).json(publicErrorObject);
-  }
+    },
+  });
 }
-
-export default status;

--- a/pages/api/v1/status/index.js
+++ b/pages/api/v1/status/index.js
@@ -1,6 +1,6 @@
-import { createRouter } from "next-connect"
+import { createRouter } from "next-connect";
 import database from "infra/database.js";
-import controller from "infra/controller"
+import controller from "infra/controller";
 
 const router = createRouter();
 

--- a/tests/integration/api/v1/status/post.test.js
+++ b/tests/integration/api/v1/status/post.test.js
@@ -8,7 +8,7 @@ describe("POST /api/v1/status", () => {
   describe("Anonymous user", () => {
     test("Retrieving current system status", async () => {
       const response = await fetch("http://localhost:3000/api/v1/status", {
-        method: "POST"
+        method: "POST",
       });
       expect(response.status).toBe(405);
 
@@ -17,8 +17,9 @@ describe("POST /api/v1/status", () => {
       expect(responseBody).toEqual({
         name: "MethodNotAllowedError",
         message: "Método não permitido para este endpoint.",
-        action: "Verifique se o método HTTP enviado é válido para este endpoint.",
-        status_code: 405
+        action:
+          "Verifique se o método HTTP enviado é válido para este endpoint.",
+        status_code: 405,
       });
     });
   });

--- a/tests/integration/api/v1/status/post.test.js
+++ b/tests/integration/api/v1/status/post.test.js
@@ -1,0 +1,25 @@
+import orchestrator from "tests/orchestrator.js";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+});
+
+describe("POST /api/v1/status", () => {
+  describe("Anonymous user", () => {
+    test("Retrieving current system status", async () => {
+      const response = await fetch("http://localhost:3000/api/v1/status", {
+        method: "POST"
+      });
+      expect(response.status).toBe(405);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "MethodNotAllowedError",
+        message: "Método não permitido para este endpoint.",
+        action: "Verifique se o método HTTP enviado é válido para este endpoint.",
+        status_code: 405
+      });
+    });
+  });
+});


### PR DESCRIPTION
1. Padroniza os Controllers dos endpoints `/migration` e `/status`.
2. Adiciona 2 novos erros customizados: `MethodNotAllowedError` e `ServiceError`.
3. Faz o `InternalServerError` aceitar injeção do `statusCode`.

Fixes #24